### PR TITLE
✨ Add general functions to skip withespaces

### DIFF
--- a/src/GeneralParse.hs
+++ b/src/GeneralParse.hs
@@ -76,26 +76,6 @@ parseInt = do
     digits <- some parseDigit
     return (read (sign ++ digits))
 
-parseTuple :: Parser a -> Parser (a, a)
-parseTuple p = do
-    parseChar '('
-    a <- p
-    parseChar ','
-    b <- p
-    parseChar ')'
-    return (a, b)
-
-parseTruple :: Parser a -> Parser (a, a, a)
-parseTruple p = do
-    parseChar '('
-    a <- p
-    parseChar ','
-    b <- p
-    parseChar ','
-    c <- p
-    parseChar ')'
-    return (a, b, c)
-
 parseString :: String -> Parser String
 parseString = traverse parseChar
 
@@ -107,3 +87,26 @@ parseWhitespace = () <$ many (parseAnyChar " \t\n\r")
 
 consumeWhitespaces :: Parser a -> Parser a
 consumeWhitespaces p = parseWhitespace *> p <* parseWhitespace
+
+symbol :: Char -> Parser Char
+symbol c = consumeWhitespaces (parseChar c)
+
+parseTuple :: Parser a -> Parser (a, a)
+parseTuple p = do
+    symbol '('
+    a <- consumeWhitespaces p
+    symbol ','
+    b <- consumeWhitespaces p
+    symbol ')'
+    return (a, b)
+
+parseTruple :: Parser a -> Parser (a, a, a)
+parseTruple p = do
+    symbol '('
+    a <- consumeWhitespaces p
+    symbol ','
+    b <- consumeWhitespaces p
+    symbol ','
+    c <- consumeWhitespaces p
+    symbol ')'
+    return (a, b, c)


### PR DESCRIPTION
# Cool functions for you guys
These two functions might be of some help for u.

parseWhitespace makes it easier to skip one / multiple useless characters.

consumeWhitespaces is more interesting as it allows you to run a parser without worrying about usless characters.
ex: 

``` Haskell
symbol c = consumeWhitespaces (parseChar c)

integer = consumeWhitespaces parseInt
```
*With these two alliases you can write this kind of stuff without worrying about any annoying characters :*
``` Haskell
parseTuple = do
    symbol '('
    x <- integer
    symbol ','
    y <- integer
    symbol ')'
    return (x, y)
```