### PR TITLE
6 json parser

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -4,6 +4,7 @@ description: "It's our pandoc now John !"
 dependencies:
   - base >= 4.7 && < 5
   - optparse-applicative
+  - containers
 
 library:
   source-dirs: src
@@ -15,6 +16,7 @@ executables:
     ghc-options: -Wall
     dependencies:
       - mypandoc
+      - containers
 
 tests:
   unit-tests:

--- a/src/Document.hs
+++ b/src/Document.hs
@@ -34,11 +34,17 @@ data Header = Header {
     date :: Maybe Date
 } deriving (Show)
 
-data FormatType = Italic | Bold | Code
+data FormatType = Italic {
+    italicContent :: [Content]
+} | Bold {
+    boldContent :: [Content]
+} | Code {
+    codeContent :: String
+}
     deriving (Show)
 
 data Link = Link {
-    label :: Content,
+    label :: [Content],
     link :: String
 } deriving (Show)
 
@@ -60,7 +66,7 @@ data Section = Section {
 } deriving (Show)
 
 data CodeBlock = CodeBlock {
-    code :: String,
+    code :: [Content],
     language :: Maybe String
 } deriving (Show)
 

--- a/src/GeneralParse.hs
+++ b/src/GeneralParse.hs
@@ -51,6 +51,14 @@ parseChar c = Parser f
       | x == c = Just (c, xs)
       | otherwise = Nothing
 
+parseCharRev :: Char -> Parser Char
+parseCharRev c = Parser f
+  where
+    f [] = Nothing
+    f xs
+      | last xs == c = Just (c, init xs)
+      | otherwise    = Nothing
+
 parseAnyChar :: String -> Parser Char
 parseAnyChar s = Parser f
   where
@@ -90,6 +98,9 @@ consumeWhitespaces p = parseWhitespace *> p <* parseWhitespace
 
 symbol :: Char -> Parser Char
 symbol c = consumeWhitespaces (parseChar c)
+
+symbolRev :: Char -> Parser Char
+symbolRev c =  parseCharRev c
 
 parseTuple :: Parser a -> Parser (a, a)
 parseTuple p = do

--- a/src/JsonWriter.hs
+++ b/src/JsonWriter.hs
@@ -1,0 +1,154 @@
+{-
+-- EPITECH PROJECT, 2025
+-- MyPandoc-Mirror
+-- File description:
+-- JsonWriter
+-}
+
+module JsonWriter (
+    documentToJson
+) where
+
+import Document
+import Data.List (intercalate)
+
+escapeString :: String -> String
+escapeString = concatMap escapeChar
+  where
+    escapeChar '"'  = "\\\""
+    escapeChar '\\' = "\\\\"
+    escapeChar '\n' = "\\n"
+    escapeChar '\r' = "\\r"
+    escapeChar '\t' = "\\t"
+    escapeChar c    = [c]
+
+jsonField :: String -> String -> String
+jsonField key val = "\"" ++ key ++ "\":" ++ val
+
+maybeField :: String -> Maybe String -> [String]
+maybeField _ Nothing = []
+maybeField key (Just val) = [jsonField key val]
+
+jsonArray :: [String] -> String
+jsonArray elems = "[" ++ intercalate "," elems ++ "]"
+
+jsonString :: String -> String
+jsonString s = "\"" ++ escapeString s ++ "\""
+
+documentToJson :: Document -> String
+documentToJson doc = 
+    "{" ++ intercalate "," [
+        jsonField "header" (headerToJson (header doc)),
+        jsonField "body" (jsonArray (map contentToJson (body doc)))
+    ] ++ "}"
+
+headerToJson :: Header -> String
+headerToJson (Header title author date) =
+    "{" ++ intercalate "," (
+        [jsonField "title" (jsonString title)] ++
+        maybeField "author" (jsonString <$> author) ++
+        maybeField "date" (dateToJson date)
+    ) ++ "}"
+
+dateToJson :: Maybe Date -> Maybe String
+dateToJson = fmap (\(Date d) -> jsonString d)
+
+titleToJson :: Title -> String
+titleToJson (Title text level) =
+    "{" ++ intercalate "," [
+        jsonField "text" (jsonString text),
+        jsonField "level" (show level)
+    ] ++ "}"
+
+contentToJson :: Content -> String
+contentToJson (Text str) = textToJson str
+contentToJson (TitleContent t) = titleContentToJson t
+contentToJson (Formatted f c) = formattedToJson f c
+contentToJson (LinkContent l) = linkToJson l
+contentToJson (ImageContent i) = imageToJson i
+contentToJson (ParagraphContent p) = paragraphToJson p
+contentToJson (SectionContent s) = sectionToJson s
+contentToJson (CodeBlockContent cb) = codeBlockToJson cb
+contentToJson (ListContent l) = listToJson l
+
+textToJson :: String -> String
+textToJson str = "{" ++ intercalate "," [
+    jsonField "type" (jsonString "text"),
+    jsonField "content" (jsonString str)
+    ] ++ "}"
+
+titleContentToJson :: Title -> String
+titleContentToJson t = "{" ++ intercalate "," [
+    jsonField "type" "\"Title\"",
+    jsonField "text" (jsonString (titleText t)),
+    jsonField "level" (show (titleLevel t))
+    ] ++ "}"
+
+formattedToJson :: FormatType -> Content -> String
+formattedToJson f c = case f of
+    Italic cs -> formatCase "Italic" "italicContent" cs c
+    Bold cs   -> formatCase "Bold" "boldContent" cs c
+    Code str  -> "{" ++ intercalate "," [
+        jsonField "type" "\"Formatted\"",
+        jsonField "format" (jsonString "Code"),
+        jsonField "codeContent" (jsonString str),
+        jsonField "content" (contentToJson c)
+        ] ++ "}"
+
+formatCase :: String -> String -> [Content] -> Content -> String
+formatCase fType field cs c = 
+    "{" ++ intercalate "," [
+        jsonField "type" "\"Formatted\"",
+        jsonField "format" (jsonString fType),
+        jsonField field (jsonArray (map contentToJson cs)),
+        jsonField "content" (contentToJson c)
+    ] ++ "}"
+
+linkToJson :: Link -> String
+linkToJson (Link label linkUrl) = 
+    "{" ++ intercalate "," [
+        jsonField "type" "\"Link\"",
+        jsonField "label" (jsonArray (map contentToJson label)),
+        jsonField "url" (jsonString linkUrl)
+    ] ++ "}"
+
+imageToJson :: Image -> String
+imageToJson (Image alt url) = 
+    "{" ++ intercalate "," [
+        jsonField "type" "\"Image\"",
+        jsonField "altText" (jsonString alt),
+        jsonField "url" (jsonString url)
+    ] ++ "}"
+
+paragraphToJson :: Paragraph -> String
+paragraphToJson (Paragraph cs) = 
+    "{" ++ intercalate "," [
+        jsonField "type" "\"Paragraph\"",
+        jsonField "content" (jsonArray (map contentToJson cs))
+    ] ++ "}"
+
+sectionToJson :: Section -> String
+sectionToJson (Section mt cs) = 
+    "{" ++ intercalate "," (
+        [jsonField "type" "\"Section\""]
+        ++ maybeField "title" (titleToJson <$> mt)
+        ++ [jsonField "content" (jsonArray (map contentToJson cs))]
+    ) ++ "}"
+
+codeBlockToJson :: CodeBlock -> String
+codeBlockToJson (CodeBlock cs lang) = 
+    "{" ++ intercalate "," (
+        [jsonField "type" "\"CodeBlock\"",
+         jsonField "code" (jsonArray (map contentToJson cs))]
+        ++ maybeField "language" (jsonString <$> lang)
+    ) ++ "}"
+
+listToJson :: List -> String
+listToJson (List items) = 
+    "{" ++ intercalate "," [
+        jsonField "type" "\"List\"",
+        jsonField "items" (jsonArray (map itemToJson items))
+    ] ++ "}"
+
+itemToJson :: Item -> String
+itemToJson (Item cs) = jsonArray (map contentToJson cs)

--- a/src/XMLParse.hs
+++ b/src/XMLParse.hs
@@ -19,13 +19,19 @@ data Balise = Balise {
     baliseArgs :: Maybe [BaliseArg]
 }deriving (Show, Eq)
 
-getString:: String -> String
-getString (x:xs)
-    | x == '<' = getString xs
-    | x == '>' = ""
-    | otherwise = [x] ++ getString xs
+parseTitle :: Parser String
+parseTitle = Parser f
+  where
+    f [] = Nothing
+    f input =
+      let (title, rest) = span (\c -> c /= '>' && c /= ' ') input
+      in if null title
+         then Nothing
+         else Just (title, rest)
 
-startXML:: String -> Maybe String
-startXML a
-    | head a /= '<' || last a /= '>' = Nothing
-    | otherwise = Just (getString a)
+parseBalise :: Parser Balise
+parseBalise = do
+    symbol '<'
+    title <- parseTitle
+    symbolRev '>'
+    return (Balise title Nothing)

--- a/src/XMLParse.hs
+++ b/src/XMLParse.hs
@@ -310,7 +310,7 @@ parseLink = do
   url <- parseUntilChar '"'
   parseChar '"'
   parseChar '>'
-  lbl <- parseContent
+  lbl <- many parseContent
   parseString "</link>"
   return $ (Link lbl url)
 

--- a/src/XMLParse.hs
+++ b/src/XMLParse.hs
@@ -20,6 +20,8 @@ module XMLParse (
 import GeneralParse
 import Data.Char
 import Data.List
+import Data.Maybe
+import Data.Bool
 import Control.Applicative (many)
 import Debug.Trace
 
@@ -113,6 +115,15 @@ parseDoubleBalise = do
     content <- parseContentBetween
     parseSimpleBalise
     return(Balise (baliseTitle title) (Just [(BaliseArg "content" (Just content))]))
+
+parseOr:: Parser a -> Parser a -> Parser a
+parseOr (Parser p1) (Parser p2) = Parser $ \input ->
+    case p1 input of
+        Just result -> Just result
+        Nothing     -> p2 input
+
+parseXML :: Parser Balise
+parseXML = parseDoubleBalise `parseOr` parseBalise `parseOr` parseSimpleBalise
 
 --  <document>
 --  <header title=\"Simple example\"></header>

--- a/src/XMLParse.hs
+++ b/src/XMLParse.hs
@@ -133,7 +133,8 @@ parseDoubleBalise = do
     title <- getTitleBalise
     content <- parseContentBetween
     getTitleBalise
-    return(Balise (baliseTitle title) (Just [(BaliseArg "content" (Just content))]))
+    return (Balise (baliseTitle title)
+      (Just [(BaliseArg "content" (Just content))]))
 
 parseOr:: Parser a -> Parser a -> Parser a
 parseOr (Parser p1) (Parser p2) = Parser $ \input ->

--- a/src/XMLParse.hs
+++ b/src/XMLParse.hs
@@ -5,6 +5,17 @@
 -- XMLParse
 -}
 
+module XMLParse (
+    BaliseArg(..),
+    Balise(..),
+    parseMore,
+    consumeMore,
+    parseTitle,
+    parseArgTag,
+    parseArgContent,
+    parseBalise
+) where
+
 import GeneralParse
 import Data.Char
 import Data.List

--- a/src/XMLParse.hs
+++ b/src/XMLParse.hs
@@ -237,11 +237,19 @@ parseDocumentEnd :: Parser String
 parseDocumentEnd = do
   parseString "</document>"
 
+parseBody :: Parser [Content]
+parseBody = do
+    parseString ("<body>")
+    contents <- many parseContent
+    parseString ("</body>")
+    return contents
+
+
 parseXMLDocument :: Parser Document
 parseXMLDocument = do
   parseDocumentStart
   header <- parseXMLHeaderDoc
-  bodyContent <- many parseContent
+  bodyContent <- parseBody
   parseDocumentEnd
   return $ Document header bodyContent
 

--- a/src/XMLParse.hs
+++ b/src/XMLParse.hs
@@ -1,0 +1,31 @@
+{-
+-- EPITECH PROJECT, 2025
+-- MyPandoc-Mirror
+-- File description:
+-- XMLParse
+-}
+
+import GeneralParse
+import Data.Char
+import Data.List
+
+data BaliseArg = BaliseArg {
+    baliseArgTag :: String,
+    baliseArgContent :: Maybe String
+}deriving (Show, Eq)
+
+data Balise = Balise {
+    baliseTitle :: String,
+    baliseArgs :: Maybe [BaliseArg]
+}deriving (Show, Eq)
+
+getString:: String -> String
+getString (x:xs)
+    | x == '<' = getString xs
+    | x == '>' = ""
+    | otherwise = [x] ++ getString xs
+
+startXML:: String -> Maybe String
+startXML a
+    | head a /= '<' || last a /= '>' = Nothing
+    | otherwise = Just (getString a)

--- a/src/XMLParse.hs
+++ b/src/XMLParse.hs
@@ -75,7 +75,7 @@ parseBalise = do
     title <- parseTitle
     argtag <- consumeWhitespaces parseArgTag
     argcontent <- consumeXMLWhitespaces parseArgContent
-    symbolRev '>'
+    symbol '>'
     return (Balise title (Just [(BaliseArg argtag (Just argcontent))]))
 
 parseSimpleBalise :: Parser Balise
@@ -84,3 +84,10 @@ parseSimpleBalise = do
     title <- parseTitle
     symbolRev '>'
     return (Balise title Nothing)
+
+--  <document>
+--  <header title="Simple example"></header>
+--  <body>
+--  <paragraph>This is a simple example</paragraph>
+--  </body>
+--  </document>

--- a/src/XMLWriter.hs
+++ b/src/XMLWriter.hs
@@ -5,7 +5,7 @@
 -- XMLWriter
 -}
 
-module XMLParse (
+module XMLWriter (
     documentToXML
 ) where
 

--- a/src/XMLWriter.hs
+++ b/src/XMLWriter.hs
@@ -17,11 +17,10 @@ import Data.Maybe
 
 writeXMLToFile :: String -> FilePath -> IO ()
 writeXMLToFile content filePath = writeFile filePath content
-
 documentToXML :: Document -> String
 documentToXML (Document h b) =
   "<document>\n" ++ headerToXML h ++
-    concatMap contentToXML b ++ "\t<body>\n</document>"
+    concatMap contentToXML b ++ "\t</body>\n</document>"
 
 headerToXML :: Header -> String
 headerToXML (Header title mAuthor mDate) =
@@ -33,7 +32,7 @@ headerToXML (Header title mAuthor mDate) =
 contentToXML :: Content -> String
 contentToXML (Text s)              = s
 contentToXML (TitleContent t)      = "\t\t" ++ titleToXML t
-contentToXML (Formatted ft c)      = "\t\t" ++ formatToXML ft c
+contentToXML (Formatted ft _)      = "\t\t" ++ formatToXML ft
 contentToXML (LinkContent l)       = "\t\t" ++ linkToXML l
 contentToXML (ImageContent i)      = "\t\t" ++ imageToXML i
 contentToXML (ParagraphContent p)  = "\t\t" ++ paragraphToXML p
@@ -42,40 +41,43 @@ contentToXML (CodeBlockContent c)  = "\t\t" ++ codeBlockToXML c
 contentToXML (ListContent l)       = "\t\t" ++ listToXML l
 
 titleToXML :: Title -> String
-titleToXML (Title t level) = "<title level=\"" ++ show level
-    ++ "\">" ++ t ++ "</title>\n"
+titleToXML (Title t level) =
+  "<title level=\"" ++ show level ++ "\">" ++ t ++ "</title>\n"
 
-formatToXML :: FormatType -> Content -> String
-formatToXML Italic c = "<italic>" ++ contentToXML c ++ "</italic>"
-formatToXML Bold c   = "<bold>" ++ contentToXML c ++ "</bold>"
-formatToXML Code c   = "<code>" ++ contentToXML c ++ "</code>"
+formatToXML :: FormatType -> String
+formatToXML (Italic c) = "<italic>" ++ concatMap contentToXML c ++ "</italic>"
+formatToXML (Bold c)   = "<bold>"   ++ concatMap contentToXML c ++ "</bold>"
+formatToXML (Code s)   = "<code>"   ++ s ++ "</code>"
 
 linkToXML :: Link -> String
-linkToXML (Link label url) = "<link url=\"" ++ url ++ "\">"
-    ++ contentToXML label ++ "</link>\n"
+linkToXML (Link label url) =
+  "<link url=\"" ++ url ++ "\">"
+  ++ concatMap contentToXML label ++ "</link>\n"
 
 imageToXML :: Image -> String
-imageToXML (Image alt url) = "<image alt=\"" ++ alt ++ "\" url=\""
-    ++ url ++ "\"/>\n"
+imageToXML (Image alt url) =
+  "<image alt=\"" ++ alt ++ "\" url=\"" ++ url ++ "\"/>\n"
 
 paragraphToXML :: Paragraph -> String
-paragraphToXML (Paragraph content) = "<paragraph>" ++
-    concatMap contentToXML content ++ "</paragraph>\n"
+paragraphToXML (Paragraph content) =
+  "<paragraph>" ++ concatMap contentToXML content ++ "</paragraph>\n"
 
 sectionToXML :: Section -> String
 sectionToXML (Section mTitle body) =
-  "<section>\n\t\t\t" ++ maybe "" (titleToXML) mTitle ++
-    concatMap contentToXML body ++ "\t\t</section>\n"
+  "<section>\n\t\t\t"
+  ++ maybe "" titleToXML mTitle
+  ++ concatMap contentToXML body
+  ++ "\t\t</section>\n"
 
 codeBlockToXML :: CodeBlock -> String
 codeBlockToXML (CodeBlock code mLang) =
-  "<codeblock>" ++ maybe "" (\l -> " language=\"" ++ l ++ "\"") mLang ++
-    ">" ++ code ++ "</codeblock>\n"
+  "<codeblock" ++ maybe "" (\l -> " language=\"" ++ l ++ "\"") mLang ++ ">"
+  ++ concatMap contentToXML code ++ "</codeblock>\n"
 
 listToXML :: List -> String
-listToXML (List items) = "<list>\n" ++ concatMap itemToXML items
-    ++ "\t\t</list>\n"
+listToXML (List items) =
+  "<list>\n" ++ concatMap itemToXML items ++ "\t\t</list>\n"
 
 itemToXML :: Item -> String
-itemToXML (Item content) = "\t\t\t<item>" ++
-    concatMap contentToXML content ++ "</item>\n"
+itemToXML (Item content) =
+  "\t\t\t<item>" ++ concatMap contentToXML content ++ "</item>\n"

--- a/src/XMLWriter.hs
+++ b/src/XMLWriter.hs
@@ -1,0 +1,81 @@
+{-
+-- EPITECH PROJECT, 2025
+-- MyPandoc-Mirror
+-- File description:
+-- XMLWriter
+-}
+
+module XMLParse (
+    documentToXML
+) where
+
+import GeneralParse
+import Document
+import Data.Char
+import Data.List
+import Data.Maybe
+
+writeXMLToFile :: String -> FilePath -> IO ()
+writeXMLToFile content filePath = writeFile filePath content
+
+documentToXML :: Document -> String
+documentToXML (Document h b) =
+  "<document>\n" ++ headerToXML h ++
+    concatMap contentToXML b ++ "\t<body>\n</document>"
+
+headerToXML :: Header -> String
+headerToXML (Header title mAuthor mDate) =
+  "\t<header title=\"" ++ title ++ "\">"
+  ++ maybe "" (\a -> "<author>" ++ a ++ "</author>") mAuthor
+  ++ maybe "" (\(Date d) -> "<date>" ++ d ++ "</date>") mDate
+  ++ "</header>\n\t<body>\n"
+
+contentToXML :: Content -> String
+contentToXML (Text s)              = s
+contentToXML (TitleContent t)      = "\t\t" ++ titleToXML t
+contentToXML (Formatted ft c)      = "\t\t" ++ formatToXML ft c
+contentToXML (LinkContent l)       = "\t\t" ++ linkToXML l
+contentToXML (ImageContent i)      = "\t\t" ++ imageToXML i
+contentToXML (ParagraphContent p)  = "\t\t" ++ paragraphToXML p
+contentToXML (SectionContent s)    = "\t\t" ++ sectionToXML s
+contentToXML (CodeBlockContent c)  = "\t\t" ++ codeBlockToXML c
+contentToXML (ListContent l)       = "\t\t" ++ listToXML l
+
+titleToXML :: Title -> String
+titleToXML (Title t level) = "<title level=\"" ++ show level
+    ++ "\">" ++ t ++ "</title>\n"
+
+formatToXML :: FormatType -> Content -> String
+formatToXML Italic c = "<italic>" ++ contentToXML c ++ "</italic>"
+formatToXML Bold c   = "<bold>" ++ contentToXML c ++ "</bold>"
+formatToXML Code c   = "<code>" ++ contentToXML c ++ "</code>"
+
+linkToXML :: Link -> String
+linkToXML (Link label url) = "<link url=\"" ++ url ++ "\">"
+    ++ contentToXML label ++ "</link>\n"
+
+imageToXML :: Image -> String
+imageToXML (Image alt url) = "<image alt=\"" ++ alt ++ "\" url=\""
+    ++ url ++ "\"/>\n"
+
+paragraphToXML :: Paragraph -> String
+paragraphToXML (Paragraph content) = "<paragraph>" ++
+    concatMap contentToXML content ++ "</paragraph>\n"
+
+sectionToXML :: Section -> String
+sectionToXML (Section mTitle body) =
+  "<section>\n\t\t\t" ++ maybe "" (titleToXML) mTitle ++
+    concatMap contentToXML body ++ "\t\t</section>\n"
+
+codeBlockToXML :: CodeBlock -> String
+codeBlockToXML (CodeBlock code mLang) =
+  "<codeblock>" ++ maybe "" (\l -> " language=\"" ++ l ++ "\"") mLang ++
+    ">" ++ code ++ "</codeblock>\n"
+
+listToXML :: List -> String
+listToXML (List items) = "<list>\n" ++ concatMap itemToXML items
+    ++ "\t\t</list>\n"
+
+itemToXML :: Item -> String
+itemToXML (Item content) = "\t\t\t<item>" ++
+    concatMap contentToXML content ++ "</item>\n"

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -9,10 +9,10 @@ import Test.Hspec
 
 import qualified GeneralParserSpec
 import qualified JsonParseSpec
+import qualified XMLParseSpec
 
 main :: IO()
 main = hspec $ do
     describe "General Parser" GeneralParserSpec.spec
     describe "Json Parser" JsonParseSpec.spec
-
-
+    describe "XML Parser" XMLParseSpec.spec

--- a/tests/XMLParseSpec.hs
+++ b/tests/XMLParseSpec.hs
@@ -15,10 +15,79 @@ spec :: Spec
 spec = do
     describe "parseSimpleBalise" $ do
         it "Simple balise" $ do
-            runParser parseSimpleBalise "</header>" `shouldBe` Just (Balise {baliseTitle = "/header", baliseArgs = Nothing},"")
-        it "Incorrect" $ do
-            runParser parseSimpleBalise "</header a>" `shouldBe` Just (Balise {baliseTitle = "/header", baliseArgs = Nothing}," a")
+            runParser parseSimpleBalise "<balise>" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Nothing},"")
+        it "Double balise name" $ do
+            runParser parseSimpleBalise "<balise a>" `shouldBe` Nothing
         it "No <" $ do
-            runParser parseSimpleBalise "/header>" `shouldBe` Nothing
+            runParser parseSimpleBalise "balise>" `shouldBe` Nothing
         it "No >" $ do
-            runParser parseSimpleBalise "</header" `shouldBe` Nothing
+            runParser parseSimpleBalise "<balise" `shouldBe` Nothing
+    describe "parseBalise" $ do
+        it "correct" $ do
+            runParser parseBalise "<balise title=\"example\"></balise>" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Just [BaliseArg {baliseArgTag = "title", baliseArgContent = Just "example"}]},"")
+        it "Without end balise" $ do
+            runParser parseBalise "<balise title=\"example\">" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Just [BaliseArg {baliseArgTag = "title", baliseArgContent = Just "example"}]},"")
+        it "No <" $ do
+            runParser parseBalise "balise title=\"example\">" `shouldBe` Nothing
+        it "No >" $ do
+            runParser parseBalise "<balise title=\"example\"" `shouldBe` Nothing
+        it "On a simple balise" $ do
+            runParser parseBalise "<balise>" `shouldBe` Nothing
+        it "On a double balise" $ do
+            runParser parseBalise "<paragraph>example</paragraph>" `shouldBe` Nothing
+
+
+
+    describe "parseDoubleBalise" $ do
+        it "correct" $ do
+            runParser parseDoubleBalise "<paragraph>example</paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "content", baliseArgContent = Just "example"}]},"")
+        it "Without end balise" $ do
+            runParser parseDoubleBalise "<paragraph>example" `shouldBe` Nothing
+        it "No < first balise" $ do
+            runParser parseDoubleBalise "paragraph>example</paragraph>" `shouldBe` Nothing
+        it "No > first balise" $ do
+            runParser parseDoubleBalise "<paragraphexample</paragraph>" `shouldBe` Nothing
+        it "No < second balise" $ do
+            runParser parseDoubleBalise "<paragraph>example/paragraph>" `shouldBe` Nothing
+        it "No > second balise" $ do
+            runParser parseDoubleBalise "<paragraph>example</paragraph" `shouldBe` Nothing
+        it "On a simple balise" $ do
+            runParser parseDoubleBalise "<balise>" `shouldBe` Nothing
+        it "On a double balise" $ do
+            runParser parseDoubleBalise "<balise title=\"example\"></balise>" `shouldBe` Nothing
+
+
+
+    describe "parseXML simple balise" $ do
+        it "Correct" $ do
+            runParser parseXML "<balise>" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Nothing},"")
+        it "Double balise name" $ do
+            runParser parseXML "<balise a>" `shouldBe` Nothing
+        it "Character outside balise" $ do
+            runParser parseXML "<balise> a" `shouldBe` Nothing
+        it "No <" $ do
+            runParser parseXML "balise>" `shouldBe` Nothing
+        it "No >" $ do
+            runParser parseXML "<balise" `shouldBe` Nothing
+    describe "parseXML args balise" $ do
+        it "correct" $ do
+            runParser parseXML "<balise title=\"example\"></balise>" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Just [BaliseArg {baliseArgTag = "title", baliseArgContent = Just "example"}]},"")
+        it "Without end balise" $ do
+            runParser parseXML "<balise title=\"example\">" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Just [BaliseArg {baliseArgTag = "title", baliseArgContent = Just "example"}]},"")
+        it "No <" $ do
+            runParser parseXML "balise title=\"example\">" `shouldBe` Nothing
+        it "No >" $ do
+            runParser parseXML "<balise title=\"example\"" `shouldBe` Nothing
+    describe "parseXML double balise" $ do
+        it "correct" $ do
+            runParser parseXML "<paragraph>example</paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "content", baliseArgContent = Just "example"}]},"")
+        it "Without end balise" $ do
+            runParser parseXML "<paragraph>example" `shouldBe` Nothing
+        it "No < first balise" $ do
+            runParser parseXML "paragraph>example</paragraph>" `shouldBe` Nothing
+        it "No > first balise" $ do
+            runParser parseXML "<paragraphexample</paragraph>" `shouldBe` Nothing
+        it "No < second balise" $ do
+            runParser parseXML "<paragraph>example/paragraph>" `shouldBe` Nothing
+        it "No > second balise" $ do
+            runParser parseXML "<paragraph>example</paragraph" `shouldBe` Nothing

--- a/tests/XMLParseSpec.hs
+++ b/tests/XMLParseSpec.hs
@@ -1,0 +1,24 @@
+{-
+-- EPITECH PROJECT, 2025
+-- MyPandoc-Mirror
+-- File description:
+-- XMLParseSpec
+-}
+
+module XMLParseSpec where
+
+import Test.Hspec
+import GeneralParse (runParser)
+import XMLParse
+
+spec :: Spec
+spec = do
+    describe "parseSimpleBalise" $ do
+        it "Simple balise" $ do
+            runParser parseSimpleBalise "</header>" `shouldBe` Just (Balise {baliseTitle = "/header", baliseArgs = Nothing},"")
+        it "Incorrect" $ do
+            runParser parseSimpleBalise "</header a>" `shouldBe` Just (Balise {baliseTitle = "/header", baliseArgs = Nothing}," a")
+        it "No <" $ do
+            runParser parseSimpleBalise "/header>" `shouldBe` Nothing
+        it "No >" $ do
+            runParser parseSimpleBalise "</header" `shouldBe` Nothing

--- a/tests/XMLParseSpec.hs
+++ b/tests/XMLParseSpec.hs
@@ -37,7 +37,9 @@ spec = do
             runParser parseBalise "<paragraph>example</paragraph>" `shouldBe` Nothing
     describe "parseDoubleBalise" $ do
         it "correct" $ do
-            runParser parseDoubleBalise "<paragraph>example</paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "content", baliseArgContent = Just "example"}]},"")
+            runParser parseDoubleBalise "<paragraph>example</paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "paragraph", baliseArgContent = Just "example"}]},"")
+        it "Balise between balise" $ do
+            runParser parseDoubleBalise "<paragraph><test>example</test></paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "test", baliseArgContent = Just "example"}]},"")
         it "Without end balise" $ do
             runParser parseDoubleBalise "<paragraph>example" `shouldBe` Nothing
         it "No < first balise" $ do
@@ -74,7 +76,9 @@ spec = do
             runParser parseXML "<balise title=\"example\"" `shouldBe` Nothing
     describe "parseXML double balise" $ do
         it "correct" $ do
-            runParser parseXML "<paragraph>example</paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "content", baliseArgContent = Just "example"}]},"")
+            runParser parseXML "<paragraph>example</paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "paragraph", baliseArgContent = Just "example"}]},"")
+        it "Balise between balise" $ do
+            runParser parseXML "<paragraph><test>example</test></paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "test", baliseArgContent = Just "example"}]},"")
         it "Without end balise" $ do
             runParser parseXML "<paragraph>example" `shouldBe` Nothing
         it "No < first balise" $ do

--- a/tests/XMLParseSpec.hs
+++ b/tests/XMLParseSpec.hs
@@ -15,7 +15,7 @@ spec :: Spec
 spec = do
     describe "parseSimpleBalise" $ do
         it "Simple balise" $ do
-            runParser parseSimpleBalise "<balise>" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Nothing},"")
+            runParser parseSimpleBalise "<balise>" `shouldBe` Just (Balise {balTit = "balise", balArg = Nothing},"")
         it "Double balise name" $ do
             runParser parseSimpleBalise "<balise a>" `shouldBe` Nothing
         it "No <" $ do
@@ -24,9 +24,9 @@ spec = do
             runParser parseSimpleBalise "<balise" `shouldBe` Nothing
     describe "parseBalise" $ do
         it "correct" $ do
-            runParser parseBalise "<balise title=\"example\"></balise>" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Just [BaliseArg {baliseArgTag = "title", baliseArgContent = Just "example"}]},"")
+            runParser parseBalise "<balise title=\"example\"></balise>" `shouldBe` Just (Balise {balTit = "balise", balArg = Just [BaliseArg {bT = "title", bC = Just "example"}]},"")
         it "Without end balise" $ do
-            runParser parseBalise "<balise title=\"example\">" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Just [BaliseArg {baliseArgTag = "title", baliseArgContent = Just "example"}]},"")
+            runParser parseBalise "<balise title=\"example\">" `shouldBe` Just (Balise {balTit = "balise", balArg = Just [BaliseArg {bT = "title", bC = Just "example"}]},"")
         it "No <" $ do
             runParser parseBalise "balise title=\"example\">" `shouldBe` Nothing
         it "No >" $ do
@@ -37,9 +37,9 @@ spec = do
             runParser parseBalise "<paragraph>example</paragraph>" `shouldBe` Nothing
     describe "parseDoubleBalise" $ do
         it "correct" $ do
-            runParser parseDoubleBalise "<paragraph>example</paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "paragraph", baliseArgContent = Just "example"}]},"")
+            runParser parseDoubleBalise "<paragraph>example</paragraph>" `shouldBe` Just (Balise {balTit = "paragraph", balArg = Just [BaliseArg {bT = "paragraph", bC = Just "example"}]},"")
         it "Balise between balise" $ do
-            runParser parseDoubleBalise "<paragraph><test>example</test></paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "test", baliseArgContent = Just "example"}]},"")
+            runParser parseDoubleBalise "<paragraph><test>example</test></paragraph>" `shouldBe` Just (Balise {balTit = "paragraph", balArg = Just [BaliseArg {bT = "test", bC = Just "example"}]},"")
         it "Without end balise" $ do
             runParser parseDoubleBalise "<paragraph>example" `shouldBe` Nothing
         it "No < first balise" $ do
@@ -56,7 +56,7 @@ spec = do
             runParser parseDoubleBalise "<balise title=\"example\"></balise>" `shouldBe` Nothing
     describe "parseXML simple balise" $ do
         it "Correct" $ do
-            runParser parseXML "<balise>" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Nothing},"")
+            runParser parseXML "<balise>" `shouldBe` Just (Balise {balTit = "balise", balArg = Nothing},"")
         it "Double balise name" $ do
             runParser parseXML "<balise a>" `shouldBe` Nothing
         it "Character outside balise" $ do
@@ -67,18 +67,18 @@ spec = do
             runParser parseXML "<balise" `shouldBe` Nothing
     describe "parseXML args balise" $ do
         it "correct" $ do
-            runParser parseXML "<balise title=\"example\"></balise>" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Just [BaliseArg {baliseArgTag = "title", baliseArgContent = Just "example"}]},"")
+            runParser parseXML "<balise title=\"example\"></balise>" `shouldBe` Just (Balise {balTit = "balise", balArg = Just [BaliseArg {bT = "title", bC = Just "example"}]},"")
         it "Without end balise" $ do
-            runParser parseXML "<balise title=\"example\">" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Just [BaliseArg {baliseArgTag = "title", baliseArgContent = Just "example"}]},"")
+            runParser parseXML "<balise title=\"example\">" `shouldBe` Just (Balise {balTit = "balise", balArg = Just [BaliseArg {bT = "title", bC = Just "example"}]},"")
         it "No <" $ do
             runParser parseXML "balise title=\"example\">" `shouldBe` Nothing
         it "No >" $ do
             runParser parseXML "<balise title=\"example\"" `shouldBe` Nothing
     describe "parseXML double balise" $ do
         it "correct" $ do
-            runParser parseXML "<paragraph>example</paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "paragraph", baliseArgContent = Just "example"}]},"")
+            runParser parseXML "<paragraph>example</paragraph>" `shouldBe` Just (Balise {balTit = "paragraph", balArg = Just [BaliseArg {bT = "paragraph", bC = Just "example"}]},"")
         it "Balise between balise" $ do
-            runParser parseXML "<paragraph><test>example</test></paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "test", baliseArgContent = Just "example"}]},"")
+            runParser parseXML "<paragraph><test>example</test></paragraph>" `shouldBe` Just (Balise {balTit = "paragraph", balArg = Just [BaliseArg {bT = "test", bC = Just "example"}]},"")
         it "Without end balise" $ do
             runParser parseXML "<paragraph>example" `shouldBe` Nothing
         it "No < first balise" $ do

--- a/tests/XMLParseSpec.hs
+++ b/tests/XMLParseSpec.hs
@@ -35,9 +35,6 @@ spec = do
             runParser parseBalise "<balise>" `shouldBe` Nothing
         it "On a double balise" $ do
             runParser parseBalise "<paragraph>example</paragraph>" `shouldBe` Nothing
-
-
-
     describe "parseDoubleBalise" $ do
         it "correct" $ do
             runParser parseDoubleBalise "<paragraph>example</paragraph>" `shouldBe` Just (Balise {baliseTitle = "paragraph", baliseArgs = Just [BaliseArg {baliseArgTag = "content", baliseArgContent = Just "example"}]},"")
@@ -55,9 +52,6 @@ spec = do
             runParser parseDoubleBalise "<balise>" `shouldBe` Nothing
         it "On a double balise" $ do
             runParser parseDoubleBalise "<balise title=\"example\"></balise>" `shouldBe` Nothing
-
-
-
     describe "parseXML simple balise" $ do
         it "Correct" $ do
             runParser parseXML "<balise>" `shouldBe` Just (Balise {baliseTitle = "balise", baliseArgs = Nothing},"")


### PR DESCRIPTION
This pull request introduces significant enhancements to the `MyPandoc-Mirror` project, focusing on JSON and XML parsing, serialization, and document structure improvements. Key changes include implementing JSON and XML parsing and writing capabilities, updating the document model for better flexibility, and refining parsing utilities. Below is a breakdown of the most important changes grouped by theme.

### JSON Parsing and Serialization
* Added a new module `JsonParse` with functions to parse JSON into `Document` objects and convert JSON structures into internal representations. Introduced `jsonToDocument`, `jsonToHeader`, and `jsonToContent` for parsing JSON into document components. [[1]](diffhunk://#diff-8cff191cfedcc6a9b90768717ad9099bb9e49750e718aed64572da6faa8de4a8R20-R29) [[2]](diffhunk://#diff-8cff191cfedcc6a9b90768717ad9099bb9e49750e718aed64572da6faa8de4a8R157-R195)
* Added a new module `JsonWriter` to serialize `Document` objects into JSON strings, including support for headers, body content, and various content types such as formatted text, links, and sections.

### XML Parsing
* Added a new module `XMLParse` to parse XML into `Document` objects, including support for headers, body content, and nested elements such as sections, paragraphs, and lists. Introduced utilities like `parseXMLDocument`, `parseSection`, and `parseContent`.

### Document Model Enhancements
* Updated `FormatType` in `src/Document.hs` to support structured content for `Italic`, `Bold`, and `Code` types, enabling nested formatting.
* Modified `CodeBlock` to allow a list of `Content` instead of a plain string, improving flexibility for code representation.

### Parsing Utilities
* Added `parseCharRev` and `symbolRev` to `src/GeneralParse.hs` for reverse parsing capabilities, expanding the flexibility of the parsing library. [[1]](diffhunk://#diff-a6e87305fb8e931325e6e431a94e59ea767a388f0c97dd2d5277911618c3de29R54-R61) [[2]](diffhunk://#diff-a6e87305fb8e931325e6e431a94e59ea767a388f0c97dd2d5277911618c3de29R102-R104)

### Dependency Updates
* Added `containers` as a dependency in `package.yaml` to support operations on maps and lists required for JSON and XML parsing. [[1]](diffhunk://#diff-e0ee4e21f8811c1171864cc68ea4005347b1b0ca70626026f251bf4111c2aa6eR7) [[2]](diffhunk://#diff-e0ee4e21f8811c1171864cc68ea4005347b1b0ca70626026f251bf4111c2aa6eR19)